### PR TITLE
Add metric_collector decorator that measures elapsed time

### DIFF
--- a/src/backend/adapter/metric_measure.py
+++ b/src/backend/adapter/metric_measure.py
@@ -1,0 +1,17 @@
+from time import perf_counter
+
+
+def metric_measure(f):
+
+    def inner(*args, **kwargs):
+        start_time = perf_counter()
+        alg_result = f(*args, **kwargs)
+        end_time = perf_counter()
+        execution_time = end_time - start_time
+        return {
+            "alg_result": alg_result,
+            "elapsed_time": execution_time
+        }
+
+    return inner
+


### PR DESCRIPTION
This is decorator called metric_measure which measures the elapsed time and return it as a dict:

Example respond: 

```
{ 
"elapsed time" : 0.513,
"alg_result" : {
      "expanded_nodes" : 55,
      "path: : [...]
}
```